### PR TITLE
Allow Query() to accept parameterized SQL values

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -43,8 +43,8 @@ func (*SQL) Open(database string, connectionString string) (*dbsql.DB, error) {
 	return db, nil
 }
 
-func (*SQL) Query(db *dbsql.DB, query string) ([]keyValue, error) {
-	rows, err := db.Query(query)
+func (*SQL) Query(db *dbsql.DB, query string, args ...interface{}) ([]keyValue, error) {
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/mssql_test.js
+++ b/tests/mssql_test.js
@@ -19,7 +19,7 @@ export function teardown() {
 export default function () {
   db.exec("INSERT INTO keyvalues ([key], [value]) VALUES('plugin-name', 'k6-plugin-sql');");
 
-  let results = sql.query(db, "SELECT * FROM keyvalues;");
+  let results = sql.query(db, "SELECT * FROM keyvalues WHERE key = $1;", 'plugin-name');
   for (const row of results) {
     console.log(`key: ${row.key}, value: ${row.value}`);
   }

--- a/tests/postgres_test.js
+++ b/tests/postgres_test.js
@@ -18,7 +18,7 @@ export function teardown() {
 
 export default function () {
   db.exec("INSERT INTO keyvalues (key, value) VALUES('plugin-name', 'k6-plugin-sql');");
-  let results = sql.query(db, 'SELECT * FROM keyvalues;');
+  let results = sql.query(db, 'SELECT * FROM keyvalues WHERE key = $1;', 'plugin-name');
   for (const row of results) {
     console.log(`key: ${row.key}, value: ${row.value}`);
   }

--- a/tests/sqlite3_test.js
+++ b/tests/sqlite3_test.js
@@ -16,7 +16,7 @@ export function teardown() {
 export default function () {
   db.exec("INSERT INTO keyvalues (key, value) VALUES('plugin-name', 'k6-plugin-sql');");
 
-  let results = sql.query(db, "SELECT * FROM keyvalues;");
+  let results = sql.query(db, "SELECT * FROM keyvalues WHERE key = $1;", 'plugin-name');
   for (const row of results) {
     console.log(`key: ${row.key}, value: ${row.value}`);
   }


### PR DESCRIPTION
This way we can benefit from Go's built-in SQL escaping routines without having to do DB-specific string escaping in the load testing script itself.